### PR TITLE
Add Discord thread functionality and fix bugs

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,11 @@
 import Hero from "@/components/Hero";
-import QuestionList from "@/components/QuestionList";
+import QuestionListWrapper from "@/components/QuestionListWrapper";
 
 export default function Home() {
   return (
-    <>
-      <main className="flex-1">
-        <Hero />
-        <QuestionList />
-      </main>
-    </>
+    <main className="flex-1">
+      <Hero />
+      <QuestionListWrapper />
+    </main>
   );
 }

--- a/src/app/question/[id]/page.tsx
+++ b/src/app/question/[id]/page.tsx
@@ -1,47 +1,25 @@
+import { Suspense } from "react";
+import { fetchDiscordThread } from "@/lib/discord";
 import QuestionDetail from "@/components/QuestionDetail";
-import AnswerList from "@/components/AnswerList";
-import AnswerForm from "@/components/AnswerForm";
-import { Question, Answer } from "@/types";
 
-// This would typically come from an API or database
-const question: Question = {
-  id: "1",
-  title: "How to center a div in CSS?",
-  content:
-    "I'm trying to center a div both horizontally and vertically within its parent container. I've tried using margin: auto but it only centers horizontally. What's the best way to achieve this?",
-  tags: ["css", "html", "flexbox"],
-  votes: 42,
-  views: 1337,
-  answers: 5,
-  author: "CSSMaster",
-  timeAgo: "2 hours ago",
-};
-
-const answers: Answer[] = [
-  {
-    id: 1,
-    content:
-      "You can use Flexbox to center a div both horizontally and vertically. Here's how:\n\n```css\n.parent {\n  display: flex;\n  justify-content: center;\n  align-items: center;\n  height: 100vh; /* Adjust as needed */\n}\n```\n\nThis will make the parent a flex container and center its children both horizontally and vertically.",
-    author: "FlexboxPro",
-    votes: 15,
-    timeAgo: "1 hour ago",
-  },
-  {
-    id: 2,
-    content:
-      "Another approach is to use CSS Grid:\n\n```css\n.parent {\n  display: grid;\n  place-items: center;\n  height: 100vh; /* Adjust as needed */\n}\n```\n\nThis is a more modern approach and works great for centering items.",
-    author: "GridMaster",
-    votes: 8,
-    timeAgo: "45 minutes ago",
-  },
-];
-
-export default function QuestionPage() {
+export default async function QuestionPage({
+  params,
+}: {
+  params: { id: string };
+}) {
   return (
-    <section className="container mx-auto px-4 py-16 max-w-4xl">
-      <QuestionDetail question={question} />
-      <AnswerList answers={answers} />
-      <AnswerForm />
-    </section>
+    <Suspense fallback={<div>Loading question...</div>}>
+      <QuestionContent id={params.id} />
+    </Suspense>
   );
+}
+
+async function QuestionContent({ id }: { id: string }) {
+  const question = await fetchDiscordThread(id);
+
+  if (!question) {
+    return <div>Question not found</div>;
+  }
+
+  return <QuestionDetail question={question} />;
 }

--- a/src/app/question/[id]/page.tsx
+++ b/src/app/question/[id]/page.tsx
@@ -1,25 +1,5 @@
-import { Suspense } from "react";
-import { fetchDiscordThread } from "@/lib/discord";
-import QuestionDetail from "@/components/QuestionDetail";
+import QuestionDetailWrapper from "@/components/QuestionDetailWrapper";
 
-export default async function QuestionPage({
-  params,
-}: {
-  params: { id: string };
-}) {
-  return (
-    <Suspense fallback={<div>Loading question...</div>}>
-      <QuestionContent id={params.id} />
-    </Suspense>
-  );
-}
-
-async function QuestionContent({ id }: { id: string }) {
-  const question = await fetchDiscordThread(id);
-
-  if (!question) {
-    return <div>Question not found</div>;
-  }
-
-  return <QuestionDetail question={question} />;
+export default function QuestionPage({ params }: { params: { id: string } }) {
+  return <QuestionDetailWrapper id={params.id} />;
 }

--- a/src/components/AnswerItem.tsx
+++ b/src/components/AnswerItem.tsx
@@ -6,11 +6,7 @@ import { Answer } from "@/types";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { tomorrow } from "react-syntax-highlighter/dist/esm/styles/prism";
 
-interface AnswerItemProps {
-  answer: Answer;
-}
-
-const AnswerItem: React.FC<AnswerItemProps> = ({ answer }) => {
+const AnswerItem = ({ answer }: { answer: Answer }) => {
   const renderContent = (content: string) => {
     const codeRegex = /```(\w+)?\s*([\s\S]*?)```/g;
     const parts = [];

--- a/src/components/AnswerList.tsx
+++ b/src/components/AnswerList.tsx
@@ -1,11 +1,7 @@
 import AnswerItem from "./AnswerItem";
 import { Answer } from "@/types";
 
-interface AnswerListProps {
-  answers: Answer[];
-}
-
-const AnswerList: React.FC<AnswerListProps> = ({ answers }) => {
+const AnswerList = ({ answers }: { answers: Answer[] }) => {
   return (
     <div>
       <h2 className="text-2xl font-bold text-gray-900 mb-4">

--- a/src/components/QuestionDetail.tsx
+++ b/src/components/QuestionDetail.tsx
@@ -11,7 +11,19 @@ import {
   Clock,
   User,
 } from "lucide-react";
-import { Question } from "@/types";
+import { Question, Reply } from "@/types";
+
+const ReplyItem = ({ reply }: { reply: Reply }) => (
+  <div className="border-t border-gray-200 pt-4 mt-4">
+    <p className="text-gray-700 mb-2">{reply.content}</p>
+    <div className="flex items-center text-sm text-gray-500">
+      <User className="h-4 w-4 mr-1" />
+      <span className="mr-4">{reply.author}</span>
+      <Clock className="h-4 w-4 mr-1" />
+      <span>{reply.createdAt}</span>
+    </div>
+  </div>
+);
 
 const QuestionDetail = ({ question }: { question: Question }) => {
   const [upvoted, setUpvoted] = useState(false);
@@ -74,6 +86,13 @@ const QuestionDetail = ({ question }: { question: Question }) => {
           </Button>
         </div>
       </div>
+
+      <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">
+        {question.answers} Answers
+      </h2>
+      {question.replies.map((reply) => (
+        <ReplyItem key={reply.id} reply={reply} />
+      ))}
     </div>
   );
 };

--- a/src/components/QuestionDetail.tsx
+++ b/src/components/QuestionDetail.tsx
@@ -90,7 +90,7 @@ const QuestionDetail = ({ question }: { question: Question }) => {
       <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">
         {question.answers} Answers
       </h2>
-      {question.replies.map((reply) => (
+      {question?.replies?.map((reply) => (
         <ReplyItem key={reply.id} reply={reply} />
       ))}
     </div>

--- a/src/components/QuestionDetail.tsx
+++ b/src/components/QuestionDetail.tsx
@@ -13,11 +13,7 @@ import {
 } from "lucide-react";
 import { Question } from "@/types";
 
-interface QuestionDetailProps {
-  question: Question;
-}
-
-const QuestionDetail: React.FC<QuestionDetailProps> = ({ question }) => {
+const QuestionDetail = ({ question }: { question: Question }) => {
   const [upvoted, setUpvoted] = useState(false);
   const [downvoted, setDownvoted] = useState(false);
 

--- a/src/components/QuestionDetailWrapper.tsx
+++ b/src/components/QuestionDetailWrapper.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from "react";
+import { fetchDiscordThread } from "@/lib/discord";
+import QuestionDetail from "./QuestionDetail";
+
+async function QuestionContent({ id }: { id: string }) {
+  const question = await fetchDiscordThread(id);
+
+  if (!question) {
+    return <div>Question not found</div>;
+  }
+
+  return <QuestionDetail question={question} />;
+}
+
+export default function QuestionDetailWrapper({ id }: { id: string }) {
+  return (
+    <Suspense fallback={<div>Loading question...</div>}>
+      <QuestionContent id={id} />
+    </Suspense>
+  );
+}

--- a/src/components/QuestionItem.tsx
+++ b/src/components/QuestionItem.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React, { useState } from "react";
-import { Question } from "../types";
+import Link from "next/link";
+import { Question } from "@/types";
 
 interface QuestionItemProps {
   question: Question;
@@ -18,16 +19,18 @@ const QuestionItem: React.FC<QuestionItemProps> = ({ question }) => {
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
     >
-      <h2 className="text-xl font-semibold mb-2">{question.title}</h2>
-      <p className="text-gray-600 mb-4">
-        {question.content
-          ? question.content.substring(0, 150) + "..."
-          : "No content available"}
-      </p>
-      <div className="flex justify-between items-center text-sm text-gray-500">
-        <span>by {question.author}</span>
-        <span>{question.timeAgo}</span>
-      </div>
+      <Link href={`/question/${question.id}`}>
+        <h2 className="text-xl font-semibold mb-2">{question.title}</h2>
+        <p className="text-gray-600 mb-4">
+          {question.content
+            ? question.content.substring(0, 150) + "..."
+            : "No content available"}
+        </p>
+        <div className="flex justify-between items-center text-sm text-gray-500">
+          <span>by {question.author}</span>
+          <span>{question.timeAgo}</span>
+        </div>
+      </Link>
     </div>
   );
 };

--- a/src/components/QuestionItem.tsx
+++ b/src/components/QuestionItem.tsx
@@ -4,11 +4,7 @@ import React, { useState } from "react";
 import Link from "next/link";
 import { Question } from "@/types";
 
-interface QuestionItemProps {
-  question: Question;
-}
-
-const QuestionItem: React.FC<QuestionItemProps> = ({ question }) => {
+const QuestionItem = ({ question }: { question: Question }) => {
   const [isHovered, setIsHovered] = useState(false);
 
   return (

--- a/src/components/QuestionList.tsx
+++ b/src/components/QuestionList.tsx
@@ -1,28 +1,12 @@
-import { Suspense } from "react";
 import QuestionItem from "./QuestionItem";
-import { fetchDiscordPosts } from "@/lib/discord";
+import { Question } from "@/types";
 
-async function Questions() {
-  const questions = await fetchDiscordPosts();
-
+export default function QuestionList({ questions }: { questions: Question[] }) {
   return (
     <div className="space-y-6">
       {questions.map((question) => (
         <QuestionItem key={question.id} question={question} />
       ))}
     </div>
-  );
-}
-
-export default function QuestionList() {
-  return (
-    <section className="container mx-auto px-4 py-16 max-w-4xl">
-      <h3 className="text-3xl font-bold mb-8 text-gray-800 text-center">
-        Hot Questions
-      </h3>
-      <Suspense fallback={<div>Loading questions...</div>}>
-        <Questions />
-      </Suspense>
-    </section>
   );
 }

--- a/src/components/QuestionList.tsx
+++ b/src/components/QuestionList.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import QuestionItem from "./QuestionItem";
-import { fetchDiscordPosts } from "../lib/discord";
+import { fetchDiscordPosts } from "@/lib/discord";
 
 async function Questions() {
   const questions = await fetchDiscordPosts();

--- a/src/components/QuestionListWrapper.tsx
+++ b/src/components/QuestionListWrapper.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from "react";
+import { fetchDiscordPosts } from "@/lib/discord";
+import QuestionList from "./QuestionList";
+
+async function QuestionsContent() {
+  const questions = await fetchDiscordPosts();
+  return <QuestionList questions={questions} />;
+}
+
+export default function QuestionListWrapper() {
+  return (
+    <section className="container mx-auto px-4 py-16 max-w-4xl">
+      <h3 className="text-3xl font-bold mb-8 text-gray-800 text-center">
+        Hot Questions
+      </h3>
+      <Suspense fallback={<div>Loading questions...</div>}>
+        <QuestionsContent />
+      </Suspense>
+    </section>
+  );
+}

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -4,7 +4,7 @@ import {
   ThreadChannel,
   ChannelType,
 } from "discord.js";
-import { Question } from "@/types";
+import { Question, Reply } from "@/types";
 
 const FORUM_CHANNEL_TYPE = ChannelType.GuildForum;
 const THREAD_CHANNEL_TYPE = 11;

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -1,6 +1,13 @@
-import { Client, GatewayIntentBits } from "discord.js";
+import { Client, GatewayIntentBits, ThreadChannel } from "discord.js";
 import { Question } from "@/types";
 
+/**
+ * Fetches posts from a specified Discord forum channel.
+ *
+ * @returns {Promise<Question[]>} A promise that resolves to an array of questions.
+ *
+ * @throws Will throw an error if the specified channel is not a forum channel or if there is an issue fetching the posts.
+ */
 export async function fetchDiscordPosts(): Promise<Question[]> {
   const client = new Client({
     intents: [
@@ -52,6 +59,70 @@ export async function fetchDiscordPosts(): Promise<Question[]> {
   } catch (error) {
     console.error("Error fetching Discord posts:", error);
     throw error;
+  } finally {
+    await client.destroy();
+  }
+}
+
+/**
+ * Fetches a Discord thread by its ID and returns a `Question` object containing
+ * details about the thread.
+ *
+ * @param threadId - The ID of the Discord thread to fetch.
+ * @returns A promise that resolves to a `Question` object containing details
+ * about the thread, or `null` if the thread does not exist or an error occurs.
+ *
+ * @throws Will throw an error if the specified thread does not exist or is not
+ * a public thread.
+ */
+export async function fetchDiscordThread(
+  threadId: string
+): Promise<Question | null> {
+  const client = new Client({
+    intents: [
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+      GatewayIntentBits.MessageContent,
+    ],
+  });
+
+  try {
+    await client.login(process.env.DISCORD_BOT_TOKEN);
+
+    const thread = (await client.channels.fetch(threadId)) as ThreadChannel;
+
+    if (!thread || thread.type !== 11) {
+      // 11 is the type for public thread channels
+      throw new Error(
+        "The specified thread does not exist or is not a public thread"
+      );
+    }
+
+    const messages = await thread.messages.fetch({ limit: 1 });
+    const firstMessage = messages.first();
+
+    const viewCount = "viewCount" in thread ? Number(thread.viewCount) : 0;
+    const messageCount = thread.messageCount ?? 0;
+    const createdAt = thread.createdAt
+      ? new Date(thread.createdAt).toLocaleString()
+      : "Unknown date";
+
+    const question: Question = {
+      id: thread.id,
+      title: thread.name,
+      tags: thread.appliedTags || [],
+      votes: messageCount,
+      views: viewCount,
+      answers: Math.max(0, messageCount - 1),
+      author: firstMessage?.author?.username || "Unknown",
+      timeAgo: createdAt,
+      content: firstMessage?.content || "",
+    };
+
+    return question;
+  } catch (error) {
+    console.error("Error fetching Discord thread:", error);
+    return null;
   } finally {
     await client.destroy();
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,14 @@ export interface Question {
   author: string;
   timeAgo: string;
   content: string; // Ensure this is included and not optional
+  replies: Reply[];
+}
+
+export interface Reply {
+  id: string;
+  content: string;
+  author: string;
+  createdAt: string;
 }
 
 export interface Answer {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,7 @@ export interface Question {
   author: string;
   timeAgo: string;
   content: string; // Ensure this is included and not optional
-  replies: Reply[];
+  replies?: Reply[];
 }
 
 export interface Reply {


### PR DESCRIPTION
This pull request adds new functionality to fetch unique Discord threads by ID and to link from the home page to the detail page. It also refactors the code for better segregation of concerns. Additionally, it fixes style code on the typing component props, as well as bugs related to getting messages from a thread and from the forum on the home page.