### PR TITLE
feat: add QuestionDetailSkeleton component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "lucide-react": "^0.441.0",
         "next": "14.2.11",
         "react": "^18.3.1",
+        "react-content-loader": "^7.0.2",
         "react-dom": "^18.3.1",
         "react-syntax-highlighter": "^15.5.0",
         "tailwind-merge": "^2.5.2",
@@ -4674,6 +4675,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-content-loader": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-7.0.2.tgz",
+      "integrity": "sha512-773S98JTyC8VB2nu7LXUhpHx8tZMieGxMcx3qTe7IkohT6Br7d9AXnIXs/wQ6IhlUdKQcw6JLKk1QKigYCWDRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lucide-react": "^0.441.0",
     "next": "14.2.11",
     "react": "^18.3.1",
+    "react-content-loader": "^7.0.2",
     "react-dom": "^18.3.1",
     "react-syntax-highlighter": "^15.5.0",
     "tailwind-merge": "^2.5.2",

--- a/src/components/QuestionDetailSkeleton.tsx
+++ b/src/components/QuestionDetailSkeleton.tsx
@@ -56,23 +56,22 @@ const QuestionDetailSkeleton = () => {
       <div className="flex justify-between items-center my-4">
         <ContentLoader
           speed={2}
-          height={32}
+          height={18}
           backgroundColor="#f0f0f0"
           foregroundColor="#ecebeb"
         >
-          {/* 3 Tags */}
           <rect x="0" y="0" rx="12" ry="12" width="140" height="18" />
         </ContentLoader>
 
         {/* Botones Skeleton (Upvote/Downvote) */}
         <ContentLoader
           speed={2}
-          height={40}
+          height={38}
           backgroundColor="#f0f0f0"
           foregroundColor="#ecebeb"
         >
-          <rect x="70" y="0" rx="4" ry="4" width="100" height="40" />
-          <rect x="180" y="0" rx="4" ry="4" width="120" height="40" />
+          <rect x="70" y="0" rx="4" ry="4" width="100" height="38" />
+          <rect x="180" y="0" rx="4" ry="4" width="120" height="38" />
         </ContentLoader>
       </div>
 
@@ -81,11 +80,11 @@ const QuestionDetailSkeleton = () => {
         <ContentLoader
           speed={2}
           width="100%"
-          height={40}
+          height={30}
           backgroundColor="#f0f0f0"
           foregroundColor="#ecebeb"
         >
-          <rect x="0" y="0" rx="4" ry="4" width="8%" height="40" />
+          <rect x="0" y="0" rx="4" ry="4" width="14%" height="40" />
         </ContentLoader>
       </div>
 

--- a/src/components/QuestionDetailSkeleton.tsx
+++ b/src/components/QuestionDetailSkeleton.tsx
@@ -89,7 +89,7 @@ const QuestionDetailSkeleton = () => {
         </ContentLoader>
       </div>
 
-      {[...Array(4)].map((_, index) => (
+      {[...Array(3)].map((_, index) => (
         <div key={index} className="border-t border-gray-200 pt-4 mt-4">
           <ContentLoader
             speed={2}

--- a/src/components/QuestionDetailSkeleton.tsx
+++ b/src/components/QuestionDetailSkeleton.tsx
@@ -5,7 +5,7 @@ import ContentLoader from "react-content-loader";
 const QuestionDetailSkeleton = () => {
   return (
     <div className="bg-white rounded-lg shadow-md p-6 mb-8">
-      {/* Título Skeleton */}
+      {/* Title Skeleton */}
       <ContentLoader
         speed={2}
         width="100%"
@@ -25,7 +25,7 @@ const QuestionDetailSkeleton = () => {
           backgroundColor="#f0f0f0"
           foregroundColor="#ecebeb"
         >
-          {/* Iconos y texto para views, answers, etc */}
+          {/* Icons and text for views, answers, etc */}
           <rect x="0" y="0" rx="4" ry="4" width="6%" height="16" />
           <rect x="7%" y="0" rx="4" ry="4" width="10%" height="16" />
           <rect x="18%" y="0" rx="4" ry="4" width="5%" height="16" />
@@ -33,9 +33,8 @@ const QuestionDetailSkeleton = () => {
         </ContentLoader>
       </div>
 
-      {/* Contenido del artículo Skeleton */}
+      {/* Article content skeleton */}
       <div className="my-3">
-
         <ContentLoader
           speed={2}
           width="100%"
@@ -43,14 +42,13 @@ const QuestionDetailSkeleton = () => {
           backgroundColor="#f0f0f0"
           foregroundColor="#ecebeb"
         >
-          {/* Varias líneas de texto */}
+          {/* Multiple lines of text */}
           <rect x="0" y="0" rx="4" ry="4" width="100%" height="18" />
           <rect x="0" y="25" rx="4" ry="4" width="90%" height="18" />
           <rect x="0" y="50" rx="4" ry="4" width="95%" height="18" />
           <rect x="0" y="75" rx="4" ry="4" width="60%" height="18" />
         </ContentLoader>
       </div>
-
 
       {/* Tags Skeleton */}
       <div className="flex justify-between items-center my-4">
@@ -63,7 +61,7 @@ const QuestionDetailSkeleton = () => {
           <rect x="0" y="0" rx="12" ry="12" width="140" height="18" />
         </ContentLoader>
 
-        {/* Botones Skeleton (Upvote/Downvote) */}
+        {/* Buttons Skeleton (Upvote/Downvote) */}
         <ContentLoader
           speed={2}
           height={38}
@@ -109,7 +107,7 @@ const QuestionDetailSkeleton = () => {
               backgroundColor="#f0f0f0"
               foregroundColor="#ecebeb"
             >
-              {/* Iconos y texto para views, answers, etc */}
+              {/* Icons and text for reply views, answers, etc */}
               <rect x="0" y="0" rx="4" ry="4" width="6%" height="16" />
               <rect x="7%" y="0" rx="4" ry="4" width="12%" height="16" />
             </ContentLoader>

--- a/src/components/QuestionDetailSkeleton.tsx
+++ b/src/components/QuestionDetailSkeleton.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import ContentLoader from "react-content-loader";
+
+const QuestionDetailSkeleton = () => {
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6 mb-8">
+      {/* Título Skeleton */}
+      <ContentLoader
+        speed={2}
+        width="100%"
+        height={40}
+        backgroundColor="#f0f0f0"
+        foregroundColor="#ecebeb"
+      >
+        <rect x="0" y="0" rx="4" ry="4" width="80%" height="24" />
+      </ContentLoader>
+
+      {/* Stats Skeleton (views, answers, timeAgo, author) */}
+      <div className="flex gap-2 text-sm text-gray-500 my-2">
+        <ContentLoader
+          speed={2}
+          width="100%"
+          height={24}
+          backgroundColor="#f0f0f0"
+          foregroundColor="#ecebeb"
+        >
+          {/* Iconos y texto para views, answers, etc */}
+          <rect x="0" y="0" rx="4" ry="4" width="6%" height="16" />
+          <rect x="7%" y="0" rx="4" ry="4" width="10%" height="16" />
+          <rect x="18%" y="0" rx="4" ry="4" width="5%" height="16" />
+          <rect x="24%" y="0" rx="4" ry="4" width="4%" height="16" />
+        </ContentLoader>
+      </div>
+
+      {/* Contenido del artículo Skeleton */}
+      <div className="my-3">
+
+        <ContentLoader
+          speed={2}
+          width="100%"
+          height={90}
+          backgroundColor="#f0f0f0"
+          foregroundColor="#ecebeb"
+        >
+          {/* Varias líneas de texto */}
+          <rect x="0" y="0" rx="4" ry="4" width="100%" height="18" />
+          <rect x="0" y="25" rx="4" ry="4" width="90%" height="18" />
+          <rect x="0" y="50" rx="4" ry="4" width="95%" height="18" />
+          <rect x="0" y="75" rx="4" ry="4" width="60%" height="18" />
+        </ContentLoader>
+      </div>
+
+
+      {/* Tags Skeleton */}
+      <div className="flex justify-between items-center my-4">
+        <ContentLoader
+          speed={2}
+          height={32}
+          backgroundColor="#f0f0f0"
+          foregroundColor="#ecebeb"
+        >
+          {/* 3 Tags */}
+          <rect x="0" y="0" rx="12" ry="12" width="140" height="18" />
+        </ContentLoader>
+
+        {/* Botones Skeleton (Upvote/Downvote) */}
+        <ContentLoader
+          speed={2}
+          height={40}
+          backgroundColor="#f0f0f0"
+          foregroundColor="#ecebeb"
+        >
+          <rect x="70" y="0" rx="4" ry="4" width="100" height="40" />
+          <rect x="180" y="0" rx="4" ry="4" width="120" height="40" />
+        </ContentLoader>
+      </div>
+
+      {/* Answer title */}
+      <div className="mt-10 mb-4">
+        <ContentLoader
+          speed={2}
+          width="100%"
+          height={40}
+          backgroundColor="#f0f0f0"
+          foregroundColor="#ecebeb"
+        >
+          <rect x="0" y="0" rx="4" ry="4" width="8%" height="40" />
+        </ContentLoader>
+      </div>
+
+      {[...Array(4)].map((_, index) => (
+        <div key={index} className="border-t border-gray-200 pt-4 mt-4">
+          <ContentLoader
+            speed={2}
+            width="100%"
+            height={70}
+            backgroundColor="#f0f0f0"
+            foregroundColor="#ecebeb"
+          >
+            <rect x="0" y="0" rx="4" ry="4" width="100%" height="18" />
+            <rect x="0" y="25" rx="4" ry="4" width="100%" height="18" />
+            <rect x="0" y="50" rx="4" ry="4" width="95%" height="18" />
+          </ContentLoader>
+          <div className="my-4">
+            <ContentLoader
+              speed={2}
+              width="100%"
+              height={24}
+              backgroundColor="#f0f0f0"
+              foregroundColor="#ecebeb"
+            >
+              {/* Iconos y texto para views, answers, etc */}
+              <rect x="0" y="0" rx="4" ry="4" width="6%" height="16" />
+              <rect x="7%" y="0" rx="4" ry="4" width="12%" height="16" />
+            </ContentLoader>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default QuestionDetailSkeleton;

--- a/src/components/QuestionDetailWrapper.tsx
+++ b/src/components/QuestionDetailWrapper.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { fetchDiscordThread } from "@/lib/discord";
 import QuestionDetail from "./QuestionDetail";
+import QuestionDetailSkeleton from "./QuestionDetailSkeleton";
 
 async function QuestionContent({ id }: { id: string }) {
   const question = await fetchDiscordThread(id);
@@ -14,8 +15,10 @@ async function QuestionContent({ id }: { id: string }) {
 
 export default function QuestionDetailWrapper({ id }: { id: string }) {
   return (
-    <Suspense fallback={<div>Loading question...</div>}>
-      <QuestionContent id={id} />
-    </Suspense>
+    <div className="flex-1">
+      <Suspense fallback={<QuestionDetailSkeleton />}>
+        <QuestionContent id={id} />
+      </Suspense>
+    </div>
   );
 }


### PR DESCRIPTION
### Issue
Resolves #11 

### feat: Add `QuestionDetailSkeleton` component

This PR introduces a `QuestionDetailSkeleton` component, designed to provide a skeleton loading UI for the `QuestionDetail` component. This skeleton mimics the layout and structure of a typical question detail page in the app while the actual content is being fetched or loaded.

#### Changes:
- Added the `QuestionDetailSkeleton` component using `react-content-loader` to simulate the following:
  - **Title section**: Two lines to reflect a question title with a subtitle or timestamp below.
  - **Stats section**: Placeholder icons and text for views, answers, time, and author details.
  - **Content section**: Four lines of varying lengths to represent the question content.
  - **Tags section**: Three badges to simulate tags associated with the question.
  - **Upvote/Downvote buttons**: Two buttons to represent the upvote and downvote options.
  - **Answers section**: Three placeholder entries to mimic individual answers below the question.

#### Visual Comparison:
- On the left is the actual rendered question detail page.
- On the right is the newly introduced skeleton loader, closely matching the structure and spacing of the real page.

By adding this skeleton loader, we enhance the user experience by providing a visually similar layout while data is loading, reducing perceived waiting times.


<img width="1778" alt="image" src="https://github.com/user-attachments/assets/dde2e4aa-d13a-4cc3-8e3f-b29b9afae7e0">
