### PR TITLE
feat: add code highlighting and refactor content rendering logic

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,13 @@
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import prism from "react-syntax-highlighter/dist/cjs/styles/prism/prism"; // light theme
+import { CodeBlockProps } from "@/types";
+
+const CodeBlock = ({ language, code }: CodeBlockProps) => {
+  return (
+    <SyntaxHighlighter language={language} style={prism}>
+      {code}
+    </SyntaxHighlighter>
+  );
+};
+
+export default CodeBlock;

--- a/src/components/QuestionDetail.tsx
+++ b/src/components/QuestionDetail.tsx
@@ -1,23 +1,18 @@
 "use client";
 
+import React from "react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import {
-  ArrowUp,
-  ArrowDown,
-  MessageCircle,
-  Eye,
-  Clock,
-  User,
-} from "lucide-react";
+import { ArrowUp, ArrowDown, MessageCircle, Eye, Clock, User } from "lucide-react";
 import { Question, Reply } from "@/types";
 import { getRelativeString } from "@/lib/dateUtils";
+import ContentWithCodeBlocks from "@/lib/ContentWithCodeBlocks";
 
 const ReplyItem = ({ reply }: { reply: Reply }) => (
   <div className="border-t border-gray-200 pt-4 mt-4">
-    <p className="text-gray-700 mb-2">{reply.content}</p>
-    <div className="flex items-center text-sm text-gray-500">
+    <ContentWithCodeBlocks content={reply.content} />
+    <div className="flex items-center text-sm text-gray-500 mt-2">
       <User className="h-4 w-4 mr-1" />
       <span className="mr-4">{reply.author}</span>
       <Clock className="h-4 w-4 mr-1" />
@@ -32,9 +27,7 @@ const QuestionDetail = ({ question }: { question: Question }) => {
 
   return (
     <div className="bg-white rounded-lg shadow-md p-6 mb-8">
-      <h1 className="text-3xl font-bold text-gray-900 mb-4">
-        {question.title}
-      </h1>
+      <h1 className="text-3xl font-bold text-gray-900 mb-4">{question.title}</h1>
       <div className="flex items-center text-sm text-gray-500 mb-4">
         <span className="flex items-center mr-4">
           <Eye className="h-4 w-4 mr-1" />
@@ -53,42 +46,26 @@ const QuestionDetail = ({ question }: { question: Question }) => {
           {question.author}
         </span>
       </div>
-      <p className="text-gray-700 mb-4">{question.content}</p>
-      <div className="flex items-center justify-between">
+      <ContentWithCodeBlocks content={question.content} />
+      <div className="flex items-center justify-between mt-4">
         <div className="space-x-2">
           {question.tags.map((tag) => (
-            <Badge
-              key={tag}
-              variant="secondary"
-              className="bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors duration-300"
-            >
+            <Badge key={tag} variant="secondary" className="bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors duration-300">
               {tag}
             </Badge>
           ))}
         </div>
         <div className="flex items-center space-x-2">
-          <Button
-            variant="outline"
-            size="sm"
-            className={`${upvoted ? "bg-green-100 text-green-600" : ""}`}
-            onClick={() => setUpvoted(!upvoted)}
-          >
+          <Button variant="outline" size="sm" className={`${upvoted ? "bg-green-100 text-green-600" : ""}`} onClick={() => setUpvoted(!upvoted)}>
             <ArrowUp className="h-4 w-4 mr-1" />
           </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className={`${downvoted ? "bg-red-100 text-red-600" : ""}`}
-            onClick={() => setDownvoted(!downvoted)}
-          >
+          <Button variant="outline" size="sm" className={`${downvoted ? "bg-red-100 text-red-600" : ""}`} onClick={() => setDownvoted(!downvoted)}>
             <ArrowDown className="h-4 w-4 mr-1" />
           </Button>
         </div>
       </div>
 
-      <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">
-        {question.answers} respuestas
-      </h2>
+      <h2 className="text-2xl font-bold text-gray-900 mt-8 mb-4">{question.answers} respuestas</h2>
       {question?.replies?.map((reply) => (
         <ReplyItem key={reply.id} reply={reply} />
       ))}

--- a/src/lib/ContentWithCodeBlocks.tsx
+++ b/src/lib/ContentWithCodeBlocks.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { extractCodeBlocks } from "@/lib/codeUtils";
+import CodeBlock from "@/components/CodeBlock";
+import { ContentElement } from "@/types";
+
+const ContentWithCodeBlocks = ({ content }: { content: string }) => {
+  const elements: ContentElement[] = extractCodeBlocks(content);
+
+  return (
+    <div>
+      {elements.map((element, index) => {
+        if (element.type === "text") {
+          return (
+            <span className="text-gray-700" key={`text-${index}`}>
+              {element.content}
+            </span>
+          );
+        } else if (element.type === "code") {
+          return (
+            <div className="my-4" key={`code-${index}`}>
+              <CodeBlock language={element.language} code={element.code} />
+            </div>
+          );
+        } else if (element.type === "inline") {
+          return (
+            <code key={`inline-code-${index}`} className="bg-gray-200 px-2 py-0.5 rounded">
+              {element.code}
+            </code>
+          );
+        }
+        return null;
+      })}
+    </div>
+  );
+};
+
+export default ContentWithCodeBlocks;

--- a/src/lib/codeUtils.test.ts
+++ b/src/lib/codeUtils.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { extractCodeBlocks } from "./codeUtils";
+
+describe("extractCodeBlocks", () => {
+  it("should extract a single code block with language and text before/after", () => {
+    const message = `
+      Here is some text.
+      \`\`\`js
+      console.log('hello world');
+      \`\`\`
+      More text after code.
+    `;
+
+    const result = extractCodeBlocks(message);
+
+    expect(result).toEqual([
+      { type: "text", content: "Here is some text." },
+      {
+        type: "code",
+        language: "js",
+        code: "console.log('hello world');",
+      },
+      { type: "text", content: "More text after code." },
+    ]);
+  });
+
+  it("should extract multiple code blocks with text between and their associated language", () => {
+    const message = `
+      Here is some text.
+      \`\`\`js
+      console.log('hello world');
+      \`\`\`
+      Another text.
+      \`\`\`python
+      print('hello world')
+      \`\`\`
+    `;
+
+    const result = extractCodeBlocks(message);
+
+    expect(result).toEqual([
+      { type: "text", content: "Here is some text." },
+      {
+        type: "code",
+        language: "js",
+        code: "console.log('hello world');",
+      },
+      { type: "text", content: "Another text." },
+      {
+        type: "code",
+        language: "python",
+        code: "print('hello world')",
+      },
+    ]);
+  });
+
+  it("should handle code blocks with no specified language and text before/after", () => {
+    const message = `
+      Here is some text.
+      \`\`\`
+      console.log('hello world');
+      \`\`\`
+    `;
+
+    const result = extractCodeBlocks(message);
+
+    expect(result).toEqual([
+      { type: "text", content: "Here is some text." },
+      {
+        type: "code",
+        language: "plaintext",
+        code: "console.log('hello world');",
+      },
+    ]);
+  });
+
+  it("should handle text with no code blocks", () => {
+    const message = "Just some text without code blocks.";
+
+    const result = extractCodeBlocks(message);
+
+    expect(result).toEqual([{ type: "text", content: "Just some text without code blocks." }]);
+  });
+
+  it("should handle edge cases with empty code blocks and text before/after", () => {
+    const message = `
+      Here is some text.
+      \`\`\`js
+      \`\`\`
+    `;
+
+    const result = extractCodeBlocks(message);
+
+    expect(result).toEqual([
+      { type: "text", content: "Here is some text." },
+      {
+        type: "code",
+        language: "js",
+        code: "",
+      },
+    ]);
+  });
+
+  it("should handle inline code", () => {
+    const message = "Here is some inline code: `git push -u origin main`.";
+
+    const result = extractCodeBlocks(message);
+
+    expect(result).toEqual([
+      { type: "text", content: "Here is some inline code: " },
+      {
+        type: "inline",
+        code: "git push -u origin main",
+      },
+      { type: "text", content: "." },
+    ]);
+  });
+});

--- a/src/lib/codeUtils.ts
+++ b/src/lib/codeUtils.ts
@@ -1,0 +1,46 @@
+import { ContentElement } from "@/types";
+
+export function extractCodeBlocks(message: string): ContentElement[] {
+  const blockCodeRegex = /```(\w+)?\n([\s\S]*?)```/g;
+  const inlineCodeRegex = /`([^`]+)`/g;
+  const elements: ContentElement[] = [];
+
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = blockCodeRegex.exec(message)) !== null) {
+    const beforeCode = message.slice(lastIndex, match.index).trim();
+    if (beforeCode) {
+      elements.push({ type: "text", content: beforeCode });
+    }
+    elements.push({
+      type: "code",
+      language: match[1] || "plaintext",
+      code: match[2].trim(),
+    });
+    lastIndex = blockCodeRegex.lastIndex;
+  }
+
+  const remainingContent = message.slice(lastIndex).trim();
+  if (remainingContent) {
+    let lastInlineIndex = 0;
+    while ((match = inlineCodeRegex.exec(remainingContent)) !== null) {
+      const beforeInline = remainingContent.slice(lastInlineIndex, match.index);
+      if (beforeInline) {
+        elements.push({ type: "text", content: beforeInline });
+      }
+      elements.push({
+        type: "inline",
+        code: match[1].trim(),
+      });
+      lastInlineIndex = inlineCodeRegex.lastIndex;
+    }
+
+    const afterInline = remainingContent.slice(lastInlineIndex);
+    if (afterInline) {
+      elements.push({ type: "text", content: afterInline });
+    }
+  }
+
+  return elements;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,3 +17,27 @@ export interface Reply {
   author: string;
   createdAt: string;
 }
+
+export interface CodeBlockProps {
+  language?: string;
+  code: string;
+}
+
+export interface CodeBlockElement {
+  type: "code";
+  language?: string;
+  code: string;
+}
+
+export interface TextElement {
+  type: "text";
+  content: string;
+}
+
+export interface InlineCodeElement {
+  type: "inline";
+  code: string;
+}
+
+// A unified type to represent all possible content elements
+export type ContentElement = TextElement | CodeBlockElement | InlineCodeElement;


### PR DESCRIPTION
* feat: integrate syntax highlighting for code snippets using `react-syntax-highlighter`
* refactor: update ContentWithCodeBlocks to handle block and inline code more cleanly
* refactor: extract reusable types to a global types file
* fix: resolve issue with improper rendering of inline and block code in content
resolves #20 